### PR TITLE
Added CIFAR dataset transforms

### DIFF
--- a/mcp/data/dataset/cifar.py
+++ b/mcp/data/dataset/cifar.py
@@ -5,7 +5,11 @@ from torch.utils.data import Dataset
 from torchvision.datasets import CIFAR100
 
 from mcp.data.dataset.dataset import ComposedDataset, DatasetLoader, IndexedDataset
-from mcp.data.dataset.transforms import TransformType, cifar_test_transform
+from mcp.data.dataset.transforms import TransformType, DefaultTransform
+
+# CIFAR statistics
+IMAGES_MEAN = (0.5071, 0.4867, 0.4408)
+IMAGES_STD = (0.2675, 0.2565, 0.2761)
 
 CLASSES_TRAIN = [
     "train",
@@ -120,7 +124,7 @@ class CifarFsDataset(Dataset):
         self,
         dataset: Dataset,
         classes_mapping: Dict[int, int],
-        transform: TransformType = cifar_test_transform,
+        transform: TransformType = DefaultTransform(IMAGES_MEAN, IMAGES_STD),
     ):
         self.dataset = dataset
         self.classes_mapping = classes_mapping

--- a/mcp/data/dataset/transforms.py
+++ b/mcp/data/dataset/transforms.py
@@ -2,7 +2,6 @@ from typing import Callable, Tuple, Union
 from PIL import Image
 
 import torch
-import numpy as np
 import torchvision.transforms as transforms
 
 # Transforms can be a composition, a callable function or object
@@ -20,21 +19,3 @@ class DefaultTransform(object):
 
     def __call__(self, image: Image) -> torch.Tensor:
         return self.transform(image)
-
-
-# CIFAR transformations
-CIFAR_MEAN = (0.5071, 0.4867, 0.4408)
-CIFAR_STD = (0.2675, 0.2565, 0.2761)
-# Train transform
-cifar_train_transform = transforms.Compose(
-    [
-        transforms.RandomCrop(32, padding=4),
-        transforms.ColorJitter(brightness=0.4, contrast=0.4, saturation=0.4),
-        transforms.RandomHorizontalFlip(),
-        lambda x: np.asarray(x),
-        transforms.ToTensor(),
-        transforms.Normalize(mean=CIFAR_MEAN, std=CIFAR_STD),
-    ]
-)
-# Test transform
-cifar_test_transform = DefaultTransform(CIFAR_MEAN, CIFAR_STD)


### PR DESCRIPTION
In the future we can easily add the other dataset specific transforms to `transforms.py`.

No tests right now because I'm not sure what to add as tests for transforms (help me senpai).